### PR TITLE
Check btnParams for nil before setting visibility

### DIFF
--- a/HidingBar/HidingBar.lua
+++ b/HidingBar/HidingBar.lua
@@ -1262,6 +1262,7 @@ do
 
 
 	local function SetShown(btn, show)
+   		if hb.btnParams[btn] == nil then return end
 		if hb.btnParams[btn].isShown == show then return end
 		hb.btnParams[btn].isShown = show
 		local btnData = btnSettings[btn]


### PR DESCRIPTION
A quick fix to the attempt to index a nil value. Don't know if it's a bug on HidingBar or EnhanceQoL, because EnhanceQoL is the only one that has this issue, but it works for now.

related issue: https://github.com/sfmict/HidingBar/issues/47