### PR TITLE
Fix typo in issecretvalue guard: numPounts -> numPoints

### DIFF
--- a/HidingBar/HidingBar.lua
+++ b/HidingBar/HidingBar.lua
@@ -2588,7 +2588,7 @@ do
 				return self.GetParent(noEventFrames[frame]) == self
 			end
 			status, numPoints = pcall(self.GetNumPoints, frame)
-			if status and not issecretvalue(numPounts) then
+			if status and not issecretvalue(numPoints) then
 				for i = 1, numPoints do
 					local status, _, rFrame = pcall(self.GetPoint, frame, i)
 					if status and noEventFrames[rFrame] then


### PR DESCRIPTION
Line 2591 checks `issecretvalue(numPounts)` but the variable is called `numPoints` (assigned on line 2590). Because of the typo, the guard is always checking nil, so it never fires.

In WoW 12.0, `GetNumPoints()` can return a secret value, which then hits the `for i = 1, numPoints` loop on line 2592 and crashes with `'for' limit must be a number`.

One-character fix: `numPounts` -> `numPoints`.